### PR TITLE
Add 'shared' to payment codes

### DIFF
--- a/Observer/FormConfig/Frontend/AddCheckoutBillingAddress.php
+++ b/Observer/FormConfig/Frontend/AddCheckoutBillingAddress.php
@@ -136,7 +136,7 @@ class AddCheckoutBillingAddress extends Base
             }
         }
 
-        $codes = "shared";
+        $codes[] = 'shared';
 
         return $codes;
     }

--- a/Observer/FormConfig/Frontend/AddCheckoutBillingAddress.php
+++ b/Observer/FormConfig/Frontend/AddCheckoutBillingAddress.php
@@ -136,6 +136,8 @@ class AddCheckoutBillingAddress extends Base
             }
         }
 
+        $codes = "shared";
+
         return $codes;
     }
 }


### PR DESCRIPTION
Issue #76 

I had a play around with Nigel and we concluded...

It's very hard to get the one-page setup to work, it would require an external one-page plugin. Instead, we faked the change with the inspector tool, paused the js-script on [betterbatt](https://www.betterbatt.com.au/) site, manipulated the data, and continued to run the script and it worked. 

We are quite sure this will fix the problem, but it's a bit of a gamble as we can't test it. Having that said. The implemented fix is intended to have no risk of breaking anything else. 

For the PR review. Can you see any risks or a better way to implement this? If not we'll ship it and let the client know about the change, hopefully, they'll come back to us with a 👍 .